### PR TITLE
if there are no touch states on a given frame, still run scoring logic

### DIFF
--- a/Assets/__Scripts/LED/LedCompositor.cs
+++ b/Assets/__Scripts/LED/LedCompositor.cs
@@ -26,6 +26,7 @@ public class LedCompositor : PersistentSingleton<LedCompositor>
         rgbaValues = new Color32[480],
     };
 
+    // TODO: needs to be volatile?
     private bool sendingLedData;
 
     private NativeLedOutput nativeLedOutput;

--- a/Assets/__Scripts/RhythmGame/_Managers/InputManager.cs
+++ b/Assets/__Scripts/RhythmGame/_Managers/InputManager.cs
@@ -127,8 +127,20 @@ public class InputManager : MonoBehaviour
         }
 
         // Actually handle inputs.
+        int handledStates = 0;
         foreach (TimedTouchState timedTouchState in GetTimedTouchStatesUntil(timeManager.GameplayTimeMs))
+        {
+            handledStates++;
             HandleNewTouchState(timedTouchState.TouchState, timedTouchState.TimeMs);
+        }
+
+        if (handledStates == 0)
+        {
+            // Call HandleNewTouchState with a null touch state so that ScoringManager will update state for the current
+            // time. This is idempotent for the ultimate state but will allow certain scoring info like hold notes or
+            // passing chain notes to be judged now instead of waiting for the next input.
+            HandleNewTouchState(null, timeManager.GameplayTimeMs);
+        }
     }
 }
 


### PR DESCRIPTION
Replays are sparse, so we will only record touch states where the input actually changes. This means that if a nothing is touched for a few seconds, there won't actually be any touch states for that time.

Before, we would only run the scoring logic when we had a new touch state. Now, we run scoring logic every frame, so if there is no new information we just judge with the current touch state.

The effect is that we can e.g. show misses as soon as they happen, instead of whenever the touch state finally does change.