### PR TITLE
persist data from PersistentStateManager to a TOML file

### DIFF
--- a/Assets/__Scripts/Misc/PersistentStateManager.cs
+++ b/Assets/__Scripts/Misc/PersistentStateManager.cs
@@ -1,6 +1,10 @@
-
+using System;
+using JetBrains.Annotations;
 using SaturnGame.Data;
 using SaturnGame.RhythmGame;
+using SaturnGame.Settings;
+using Tomlyn.Helpers;
+using Tomlyn.Syntax;
 
 /// <summary>
 /// The PersistentStateManager is a PersistentSingleton that can be used to track arbitrary state that should persist as
@@ -8,9 +12,92 @@ using SaturnGame.RhythmGame;
 /// </summary>
 public class PersistentStateManager : PersistentSingleton<PersistentStateManager>
 {
-    public GroupType SelectedGroupType = GroupType.Title;
-    public SortType SelectedSortType = SortType.Title;
-    public Song SelectedSong;
-    public SongDifficulty SelectedDifficulty;
+    // Note: at the moment we save this to disk every time it changes (including every time you move around in song select)
+    // We may need to change that.
+    private PersistentStateData underlyingData;
+
+    public GroupType SelectedGroupType
+    {
+        get => underlyingData.SelectedGroupType;
+        set
+        {
+            underlyingData.SelectedGroupType = value;
+            underlyingData.SaveToFile();
+        }
+    }
+
+    public SortType SelectedSortType
+    {
+        get => underlyingData.SelectedSortType;
+        set
+        {
+            underlyingData.SelectedSortType = value;
+            underlyingData.SaveToFile();
+        }
+    }
+
+    public string SelectedSongFolderPath => underlyingData.SelectedSongFolder;
+
+    [CanBeNull] private Song cachedSelectedSong;
+
+    [CanBeNull]
+    public Song SelectedSong
+    {
+        get => cachedSelectedSong?.FolderPath == underlyingData.SelectedSongFolder ? cachedSelectedSong : null;
+        set
+        {
+            cachedSelectedSong = value;
+            underlyingData.SelectedSongFolder = value?.FolderPath;
+            underlyingData.SaveToFile();
+        }
+    }
+
+    public Difficulty SelectedDifficulty => underlyingData.SelectedDifficulty;
+    public SongDifficulty SelectedDifficultyInfo
+    {
+        // Note: the "?? new()" here is kind of abusive, but it will give us an empty SongDifficulty with
+        // Difficulty = NORMAL. Proper protection is in SongSelectLogic. This is a bit of a mess, but it's not worth it
+        // to worry about right now.
+        get => SelectedSong?.SongDiffs[underlyingData.SelectedDifficulty] ?? new();
+        set
+        {
+            // If this is not a diff of the currently selected song, shit may break
+            if (SelectedSong == null || !SelectedSong.SongDiffs.ContainsValue(value))
+                throw new ArgumentException("SongDifficulty is not from the SelectedSong");
+
+            underlyingData.SelectedDifficulty = value.Difficulty;
+            underlyingData.SaveToFile();
+        }
+    }
+
+    // This is not persisted across game restarts.
     public ScoreData LastScoreData;
+
+    protected override void Awake()
+    {
+        base.Awake();
+
+        underlyingData = PersistentStateData.Load();
+    }
+}
+
+public class PersistentStateData : TomlPersistedData<PersistentStateData>
+{
+    // If new fields are added before SelectedGroupType, update the leading trivia (AddTriviaToNewFile) to be before the first one.
+    public GroupType SelectedGroupType { get; set; } = GroupType.Title;
+    public SortType SelectedSortType { get; set; } = SortType.Title;
+    public string SelectedSongFolder { get; set; }
+    public Difficulty SelectedDifficulty { get; set; } = Difficulty.Normal;
+
+    protected override string TomlFile => "state.toml";
+
+    protected override void AddTriviaToNewFile()
+    {
+        SetLeadingTrivia(TomlNamingHelper.PascalToSnakeCase(nameof(SelectedGroupType)), new()
+        {
+            new(TokenKind.Comment,
+                "# Don't mess with this unless you know what you're doing."),
+            new(TokenKind.NewLine, "\n"),
+        });
+    }
 }

--- a/Assets/__Scripts/RhythmGame/DebugChartPlayer.cs
+++ b/Assets/__Scripts/RhythmGame/DebugChartPlayer.cs
@@ -18,7 +18,7 @@ public class DebugChartPlayer : MonoBehaviour
             Song song = SongDatabase.LoadSongData(folderPath);
             SongDifficulty songDiff = song.SongDiffs[difficulty];
             PersistentStateManager.Instance.SelectedSong = song;
-            PersistentStateManager.Instance.SelectedDifficulty = songDiff;
+            PersistentStateManager.Instance.SelectedDifficultyInfo = songDiff;
             await chartManager.LoadChartAndStart();
         }
 

--- a/Assets/__Scripts/RhythmGame/_Managers/ChartManager.cs
+++ b/Assets/__Scripts/RhythmGame/_Managers/ChartManager.cs
@@ -16,7 +16,7 @@ public class ChartManager : MonoBehaviour
 
     public async Awaitable LoadChartAndStart()
     {
-        SongDifficulty difficulty = PersistentStateManager.Instance.SelectedDifficulty;
+        SongDifficulty difficulty = PersistentStateManager.Instance.SelectedDifficultyInfo;
         Chart = ChartLoader.LoadChart(difficulty.ChartFilepath);
         BGM = await AudioLoader.LoadBgm(difficulty.AudioFilepath, streamAudio: false);
 

--- a/Assets/__Scripts/RhythmGame/_Managers/ReplayManager.cs
+++ b/Assets/__Scripts/RhythmGame/_Managers/ReplayManager.cs
@@ -53,7 +53,7 @@ public class ReplayManager : MonoBehaviour
     public async Awaitable WriteReplayFile()
     {
         string chartRelativePath = Path.GetRelativePath(SongDatabase.SongPacksPath,
-            PersistentStateManager.Instance.SelectedDifficulty.ChartFilepath);
+            PersistentStateManager.Instance.SelectedDifficultyInfo.ChartFilepath);
         string timestamp = DateTime.UtcNow.ToString("o", CultureInfo.InvariantCulture);
         string replayFileName = $"replay-{chartRelativePath}-{timestamp}.json.gz";
         string escapedReplayFileName = String.Join('_', replayFileName.Split(Path.GetInvalidFileNameChars()));

--- a/Assets/__Scripts/Settings/PlayerSettings.cs
+++ b/Assets/__Scripts/Settings/PlayerSettings.cs
@@ -1,86 +1,35 @@
 using System;
-using System.Collections.Generic;
-using System.IO;
 using System.Reflection;
 using System.Runtime.Serialization;
 using SaturnGame.JetBrains.Annotations;
-using Tomlyn;
-using Tomlyn.Model;
 using Tomlyn.Syntax;
-using UnityEngine;
 
 namespace SaturnGame.Settings
 {
 [Serializable]
-public class PlayerSettings : SettingsWithTomlMetadata
+public class PlayerSettings : TomlPersistedData<PlayerSettings>
 {
     public GameSettings GameSettings { get; set; } = new();
     public UiSettings UiSettings { get; set; } = new();
     public DesignSettings DesignSettings { get; set; } = new();
     public SoundSettings SoundSettings { get; set; } = new();
 
-    private static string SettingsPath => Path.Join(Application.persistentDataPath, "settings.toml");
+    protected override string TomlFile => "settings.toml";
 
-    [NotNull]
-    public static PlayerSettings Load()
+    protected override void AddTriviaToNewFile()
     {
-        PlayerSettings loadedSettings = null;
-
-        if (File.Exists(SettingsPath))
+        // When creating new settings, add a comment and some newlines to the TOML, so it looks nicer.
+        GameSettings.SetLeadingTrivia("game_settings", new()
         {
-            try
-            {
-                FileInfo info = new(SettingsPath);
-                if (info.Length > 1_000_000)
-                    // A normal settings file should be around 1KB, not 1MB.
-                    // Something is seriously wrong, don't try to parse this.
-                    throw new($"Not trying to load {SettingsPath} - size is too large ({info.Length} bytes)");
+            new(TokenKind.Comment,
+                "# Please don't edit this file while the game is running, your changes may be lost."),
+            new(TokenKind.NewLine, "\n"),
+            new(TokenKind.NewLine, "\n"),
+        });
+        UiSettings.SetLeadingTrivia("ui_settings", new() { new(TokenKind.NewLine, "\n") });
+        DesignSettings.SetLeadingTrivia("design_settings", new() { new(TokenKind.NewLine, "\n") });
+        SoundSettings.SetLeadingTrivia("sound_settings", new() { new(TokenKind.NewLine, "\n") });
 
-                string tomlString = File.ReadAllText(SettingsPath);
-                loadedSettings = Toml.ToModel<PlayerSettings>(tomlString, SettingsPath);
-            } catch (Exception e)
-            {
-                Debug.LogError($"Failed to load settings from {SettingsPath}: {e}");
-
-                // Move current settings file to a backup if possible, otherwise we will overwrite it.
-                long unixTime = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
-                File.Move(SettingsPath, SettingsPath + $"-{unixTime}.bak");
-            }
-        }
-
-        if (loadedSettings == null)
-        {
-            loadedSettings = new();
-
-            // When creating new settings, add a comment and some newlines to the TOML so it looks nicer.
-            loadedSettings.GameSettings.SetLeadingTrivia("game_settings", new()
-            {
-                new(TokenKind.Comment,
-                    "# Please don't edit this file while the game is running, your changes may be lost."),
-                new(TokenKind.NewLine, "\n"),
-                new(TokenKind.NewLine, "\n"),
-            });
-            loadedSettings.UiSettings.SetLeadingTrivia("ui_settings", new() { new(TokenKind.NewLine, "\n") });
-            loadedSettings.DesignSettings.SetLeadingTrivia("design_settings", new() { new(TokenKind.NewLine, "\n") });
-            loadedSettings.SoundSettings.SetLeadingTrivia("sound_settings", new() { new(TokenKind.NewLine, "\n") });
-
-            loadedSettings.SaveToFile();
-        }
-
-        return loadedSettings;
-    }
-
-    private void SaveToFile()
-    {
-        // Note: Investigated rounding floats when writing:
-        // - There is no way to change the internal serialization to string.
-        // - TomlModelOptions.ConvertToToml can do arbitrary conversions during serialization, but at the end of the day
-        //   the value still needs to be one of the supported primitives. Float and double will both have some
-        //   imprecision you will see. String will be quoted. Decimal is not supported.
-        // Concluded that there is no nice way to do this in TOML without using e.g. a string value.
-        // Not worth the hassle.
-        string tomlString = Toml.FromModel(this);
-        File.WriteAllText(SettingsPath, tomlString);
     }
 
     // Given a parameter string, searches the children settings objects for the parameter.
@@ -443,53 +392,4 @@ public class SoundSettings : SettingsWithTomlMetadata
     [DataMember(Name="r_note_effect_volume")] public int RNoteEffectVolume { get; set; } = 80;
 }
 // ReSharper restore RedundantDefaultMemberInitializer
-
-public abstract class SettingsWithTomlMetadata : ITomlMetadataProvider {
-    // TOML metadata information (comments, etc.) needed for ITomlMetadataProvider
-    //TomlPropertiesMetadata ITomlMetadataProvider.PropertiesMetadata { get; set; }
-    TomlPropertiesMetadata ITomlMetadataProvider.PropertiesMetadata { get; set; }
-
-    public void SetLeadingTrivia(string propertyName, List<TomlSyntaxTriviaMetadata> trivia)
-    {
-        ITomlMetadataProvider metadataProvider = this;
-        metadataProvider.PropertiesMetadata ??= new();
-
-        metadataProvider.PropertiesMetadata.TryGetProperty(propertyName, out TomlPropertyMetadata metadata);
-        metadata ??= new();
-
-        if (metadata.LeadingTrivia != null)
-            metadata.LeadingTrivia.AddRange(trivia);
-        else
-            metadata.LeadingTrivia = trivia;
-
-        metadataProvider.PropertiesMetadata.SetProperty(propertyName, metadata);
-    }
-
-    public void DebugTrivia([NotNull] string propertyName)
-    {
-        TomlPropertiesMetadata propertiesMetadata = ((ITomlMetadataProvider)this).PropertiesMetadata;
-        if (propertiesMetadata == null)
-        {
-            Debug.Log($"{propertyName}: No properties metadata");
-            return;
-        }
-
-        propertiesMetadata.TryGetProperty(propertyName, out TomlPropertyMetadata metadata);
-
-        if (metadata == null)
-        {
-            Debug.Log($"{propertyName}: No metadata");
-            return;
-        }
-
-        Debug.Log($"{propertyName}: {metadata.LeadingTrivia?.Count} leading trivia");
-        foreach (TomlSyntaxTriviaMetadata trivia in metadata.LeadingTrivia ?? new List<TomlSyntaxTriviaMetadata>())
-            Debug.Log(trivia);
-
-        Debug.Log($"{propertyName}: {metadata.TrailingTriviaAfterEndOfLine?.Count} trailing trivia");
-        foreach (TomlSyntaxTriviaMetadata trivia in metadata.TrailingTriviaAfterEndOfLine ?? new List<TomlSyntaxTriviaMetadata>())
-            Debug.Log(trivia);
-
-    }
-}
 }

--- a/Assets/__Scripts/Settings/SettingsManager.cs
+++ b/Assets/__Scripts/Settings/SettingsManager.cs
@@ -1,7 +1,3 @@
-using Tomlyn;
-using Tomlyn.Syntax;
-using UnityEngine;
-
 namespace SaturnGame.Settings
 {
 public class SettingsManager : PersistentSingleton<SettingsManager>

--- a/Assets/__Scripts/Settings/TomlPersistedData.cs
+++ b/Assets/__Scripts/Settings/TomlPersistedData.cs
@@ -1,0 +1,120 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using JetBrains.Annotations;
+using Tomlyn;
+using Tomlyn.Model;
+using UnityEngine;
+
+namespace SaturnGame.Settings
+{
+public abstract class TomlPersistedData<T> : SettingsWithTomlMetadata where T : TomlPersistedData<T>, new()
+{
+    [NotNull] protected abstract string TomlFile { get; }
+    private string TomlPath => Path.Join(Application.persistentDataPath, TomlFile);
+
+    protected abstract void AddTriviaToNewFile();
+    
+    [NotNull]
+    public static T Load()
+    {
+        // Create a throwaway instance to get the path we should use. The path could be static but that doesn't work
+        // with inheritance.
+        string path = new T().TomlPath;
+
+        T loadedToml = null;
+
+        if (File.Exists(path))
+        {
+            try
+            {
+                FileInfo info = new(path);
+                if (info.Length > 1_000_000)
+                    // A normal settings file should be around 1KB, not 1MB.
+                    // Something is seriously wrong, don't try to parse this.
+                    throw new($"Not trying to load {path} - size is too large ({info.Length} bytes)");
+
+                string tomlString = File.ReadAllText(path);
+                loadedToml = Toml.ToModel<T>(tomlString, path);
+            } catch (Exception e)
+            {
+                Debug.LogError($"Failed to load {typeof(T).Name} from {path}: {e}");
+
+                // Move current settings file to a backup if possible, otherwise we will overwrite it.
+                long unixTime = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
+                File.Move(path, path + $"-{unixTime}.bak");
+            }
+        }
+
+        if (loadedToml != null) return loadedToml;
+
+        loadedToml = new();
+        loadedToml.AddTriviaToNewFile();
+        loadedToml.SaveToFile();
+
+        return loadedToml;
+    }
+
+    public void SaveToFile()
+    {
+        // Note: Investigated rounding floats when writing:
+        // - There is no way to change the internal serialization to string.
+        // - TomlModelOptions.ConvertToToml can do arbitrary conversions during serialization, but at the end of the day
+        //   the value still needs to be one of the supported primitives. Float and double will both have some
+        //   imprecision you will see. String will be quoted. Decimal is not supported.
+        // Concluded that there is no nice way to do this in TOML without using e.g. a string value.
+        // Not worth the hassle.
+        string tomlString = Toml.FromModel(this);
+        File.WriteAllText(TomlPath, tomlString);
+    }
+}
+
+public abstract class SettingsWithTomlMetadata : ITomlMetadataProvider {
+    // TOML metadata information (comments, etc.) needed for ITomlMetadataProvider
+    //TomlPropertiesMetadata ITomlMetadataProvider.PropertiesMetadata { get; set; }
+    TomlPropertiesMetadata ITomlMetadataProvider.PropertiesMetadata { get; set; }
+
+    public void SetLeadingTrivia([NotNull] string propertyName, List<TomlSyntaxTriviaMetadata> trivia)
+    {
+        ITomlMetadataProvider metadataProvider = this;
+        metadataProvider.PropertiesMetadata ??= new();
+
+        metadataProvider.PropertiesMetadata.TryGetProperty(propertyName, out TomlPropertyMetadata metadata);
+        metadata ??= new();
+
+        if (metadata.LeadingTrivia != null)
+            metadata.LeadingTrivia.AddRange(trivia);
+        else
+            metadata.LeadingTrivia = trivia;
+
+        metadataProvider.PropertiesMetadata.SetProperty(propertyName, metadata);
+    }
+
+    public void DebugTrivia([NotNull] string propertyName)
+    {
+        TomlPropertiesMetadata propertiesMetadata = ((ITomlMetadataProvider)this).PropertiesMetadata;
+        if (propertiesMetadata == null)
+        {
+            Debug.Log($"{propertyName}: No properties metadata");
+            return;
+        }
+
+        propertiesMetadata.TryGetProperty(propertyName, out TomlPropertyMetadata metadata);
+
+        if (metadata == null)
+        {
+            Debug.Log($"{propertyName}: No metadata");
+            return;
+        }
+
+        Debug.Log($"{propertyName}: {metadata.LeadingTrivia?.Count} leading trivia");
+        foreach (TomlSyntaxTriviaMetadata trivia in metadata.LeadingTrivia ?? new List<TomlSyntaxTriviaMetadata>())
+            Debug.Log(trivia);
+
+        Debug.Log($"{propertyName}: {metadata.TrailingTriviaAfterEndOfLine?.Count} trailing trivia");
+        foreach (TomlSyntaxTriviaMetadata trivia in metadata.TrailingTriviaAfterEndOfLine ?? new List<TomlSyntaxTriviaMetadata>())
+            Debug.Log(trivia);
+
+    }
+}
+}

--- a/Assets/__Scripts/Settings/TomlPersistedData.cs.meta
+++ b/Assets/__Scripts/Settings/TomlPersistedData.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: cc97abb6f9b14f36a1991acd296f5ecc
+timeCreated: 1723224154

--- a/Assets/__Scripts/UI/Menus/SongResults/Logic/SongResultsLogic.cs
+++ b/Assets/__Scripts/UI/Menus/SongResults/Logic/SongResultsLogic.cs
@@ -18,7 +18,7 @@ public class SongResultsLogic : MonoBehaviour
     {
         Song song = PersistentStateManager.Instance.SelectedSong;
         songTitleText.text = song.Title;
-        SongDifficulty songDifficulty = PersistentStateManager.Instance.SelectedDifficulty;
+        SongDifficulty songDifficulty = PersistentStateManager.Instance.SelectedDifficultyInfo;
         difficultyText.text = songDifficulty.Difficulty switch
         {
             Difficulty.Normal => "NORMAL",

--- a/Assets/__Scripts/UI/Menus/SongSelect/Logic/SongSelectLogic.cs
+++ b/Assets/__Scripts/UI/Menus/SongSelect/Logic/SongSelectLogic.cs
@@ -67,10 +67,10 @@ public class SongSelectLogic : MonoBehaviour
         int entryIndex = 0;
         Difficulty difficulty = 0;
 
-        if (PersistentStateManager.Instance.SelectedSong.FolderPath is string path)
+        if (PersistentStateManager.Instance.SelectedSongFolderPath is string path)
         {
             (int, int)? foundIndexes =
-                songList.FindSongFolder(path, PersistentStateManager.Instance.SelectedDifficulty.Difficulty);
+                songList.FindSongFolder(path, PersistentStateManager.Instance.SelectedDifficulty);
 
             if (foundIndexes != null)
             {
@@ -78,7 +78,7 @@ public class SongSelectLogic : MonoBehaviour
                 // We aren't guaranteed that this difficulty still exists on this song, but SetSongAndDifficulty will
                 // find the nearest difficulty in case this one no longer exists, so it should be fine.
                 // WARNING: This assumes that the difficulty index is the same as the enum value.
-                difficulty = PersistentStateManager.Instance.SelectedDifficulty.Difficulty;
+                difficulty = PersistentStateManager.Instance.SelectedDifficulty;
             }
         }
 
@@ -124,7 +124,7 @@ public class SongSelectLogic : MonoBehaviour
     {
         Dictionary<Difficulty, SongDifficulty> diffInfos = SelectedEntry.Song.SongDiffs;
         selectedDifficulty = FindNearestDifficulty(diffInfos.Keys, difficulty);
-        PersistentStateManager.Instance.SelectedDifficulty = SelectedEntry.Song.SongDiffs[selectedDifficulty];
+        PersistentStateManager.Instance.SelectedDifficultyInfo = SelectedEntry.Song.SongDiffs[selectedDifficulty];
 
         bool higherDiffExists = HigherDiff(diffInfos, selectedDifficulty) != null;
         bool lowerDiffExists = LowerDiff(diffInfos, selectedDifficulty) != null;

--- a/Assets/__Scripts/UI/RhythmGame/DifficultyText.cs
+++ b/Assets/__Scripts/UI/RhythmGame/DifficultyText.cs
@@ -22,7 +22,7 @@ public class DifficultyText : MonoBehaviour
 
     private void Start()
     {
-        SongDifficulty songDifficulty = PersistentStateManager.Instance.SelectedDifficulty;
+        SongDifficulty songDifficulty = PersistentStateManager.Instance.SelectedDifficultyInfo;
         difficulty = songDifficulty.Difficulty;
         difficultyLevel = songDifficulty.Level;
         UpdateDifficultyText();

--- a/Assets/__Scripts/UI/RhythmGame/SongTitleText.cs
+++ b/Assets/__Scripts/UI/RhythmGame/SongTitleText.cs
@@ -8,7 +8,7 @@ public class SongTitleText : MonoBehaviour
     [SerializeField] private ArcTextMeshPro arc;
     private void Start()
     {
-        UpdateText(PersistentStateManager.Instance.SelectedSong.Title);
+        UpdateText(PersistentStateManager.Instance.SelectedSong?.Title);
     }
 
     private void UpdateText(string title)


### PR DESCRIPTION
This generalizes the class that PlayerSettings uses to read/write its data to TOML, and adds a new toml file called state.toml which tracks the stuff in PersistentStateManager (except for the LastScoreData, which is really only used when going from gameplay to the results screen).

The upshot is that the game will now remember what song/diff you had selected in song selected, as well as which sorting method.